### PR TITLE
Replace `data_frame()` with `tibble()`.

### DIFF
--- a/R/00_base_tidyr.R
+++ b/R/00_base_tidyr.R
@@ -18,7 +18,7 @@ source(here::here("R", "03_check-folders.R"))
 
 # Data ----
 set.seed(42)
-wide <- data_frame(
+wide <- tibble(
   id = rep(1:2),
   x = letters[1:2],
   y = letters[3:4],

--- a/R/left_join_extra.R
+++ b/R/left_join_extra.R
@@ -1,6 +1,6 @@
 source(here::here("R/00_base_join.R"))
 
-y_extra <- bind_rows(y, data_frame(id = 2, y = "y5"))
+y_extra <- bind_rows(y, tibble(id = 2, y = "y5"))
 
 # I manually linked objects together, it was late and this was easier...
 anim_df <- tibble::tribble(
@@ -46,7 +46,7 @@ lj_extra <- animate(lj_extra)
 anim_save(here::here("images", "left-join-extra.gif"), lj_extra)
 
 ## Save static images
-df_names <- data_frame(
+df_names <- tibble(
   .x = c(1.5, 4.5), .y = 0.25,
   value = c("x", "y"),
   size = 12,

--- a/R/tidyr_spread_gather.R
+++ b/R/tidyr_spread_gather.R
@@ -33,12 +33,12 @@ sg_long$val <-
 
 sg_long <- bind_rows(sg_long) %>% mutate(frame = 2)
 
-sg_long_labels <- data_frame(id = 1, a = "id", x = "key", y = "val") %>%
+sg_long_labels <- tibble(id = 1, a = "id", x = "key", y = "val") %>%
   proc_data("4-label") %>%
   filter(label != "id") %>%
   mutate(color = "#FFFFFF", .y = 0, .x = .x -1, frame = 2, alpha = 1, label = recode(label, "a" = "id"))
 
-sg_wide_labels <- data_frame(id = 1, a = "id") %>%
+sg_wide_labels <- tibble(id = 1, a = "id") %>%
   proc_data("2-label") %>%
   filter(label != "id") %>%
   mutate(color = "#FFFFFF", .y = 0, .x = .x -1, frame = 1, alpha = 1, label = recode(label, "a" = "id"))

--- a/README.Rmd
+++ b/README.Rmd
@@ -87,7 +87,7 @@ Please visit the [pkg branch](https://github.com/gadenbuie/tidyexplain/tree/pkg)
 
 ```{r intial-dfs}
 source("R/00_base_join.R")
-df_names <- data_frame(
+df_names <- tibble(
   .x = c(1.5, 4.5), .y = 0.25,
   value = c("x", "y"),
   size = 12,
@@ -222,7 +222,7 @@ anti_join(x, y, by = "id")
 
 ```{r intial-dfs-so}
 source("R/00_base_set.R")
-df_names <- data_frame(
+df_names <- tibble(
   .x = c(2.5, 5.5), .y = 0.25,
   value = c("x", "y"),
   size = 12,


### PR DESCRIPTION
Hi Garrick!

Since using `data_frame()` now throws the once-per-session warning:
```r
#> `data_frame()` is deprecated, use `tibble()`.
#> This warning is displayed once per session.
```
I went ahead and made the switch in the tidyexplain scripts. This shouldn't change anything of substance, just a minor thing that I noticed while basking in the awesome of these animations.

Thanks,
Mara